### PR TITLE
Refactor AgeKey ToString method to use DateTimeFormatter

### DIFF
--- a/Devantler.Keys.Age/AgeKey.cs
+++ b/Devantler.Keys.Age/AgeKey.cs
@@ -53,9 +53,8 @@ public class AgeKey : IKey
   /// <returns></returns>
   public override string ToString()
   {
-    // I need the date in this format 2021-01-02T15:30:45+01:00
     return $"""
-    # created: {CreatedAt.ToString("yyyy-MM-ddTHH:mm:sszzz", CultureInfo.InvariantCulture)}
+    # created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(CreatedAt)}
     # public key: {PublicKey}
     {PrivateKey}
     """;

--- a/Devantler.Keys.Age/Utils/DateTimeFormatter.cs
+++ b/Devantler.Keys.Age/Utils/DateTimeFormatter.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+
+namespace Devantler.Keys.Age.Utils;
+
+/// <summary>
+/// A helper class for formatting DateTime objects.
+/// </summary>
+public static class DateTimeFormatter
+{
+  /// <summary>
+  /// Formats a DateTimeOffset object with a custom offset.
+  /// </summary>
+  /// <param name="dateTimeOffset"></param>
+  public static string FormatDateTimeWithCustomOffset(DateTimeOffset dateTimeOffset)
+  {
+    string dateTimeFormat = "yyyy-MM-ddTHH:mm:ss";
+    string formattedDateTime = dateTimeOffset.ToString(dateTimeFormat, CultureInfo.InvariantCulture);
+
+    return dateTimeOffset.Offset == TimeSpan.Zero ?
+      formattedDateTime + "Z" :
+      formattedDateTime + dateTimeOffset.ToString("zzz", CultureInfo.InvariantCulture);
+  }
+}
+


### PR DESCRIPTION
This pull request refactors the `AgeKey` class's `ToString` method to use the `DateTimeFormatter` class for custom offset formatting. Previously, the method used a hardcoded format string, but now it utilizes the `FormatDateTimeWithCustomOffset` method from the `DateTimeFormatter` class. This change improves code readability and maintainability.