### PR TITLE
Update AgeKey constructor to support creating key from raw key

### DIFF
--- a/Devantler.Keys.Age.Tests/AgeKeyTests/ConstructorTests.cs
+++ b/Devantler.Keys.Age.Tests/AgeKeyTests/ConstructorTests.cs
@@ -35,7 +35,7 @@ public class ConstructorTests
   }
 
   /// <summary>
-  /// Tests that an age key is created with valid data.
+  /// Tests that an exception is thrown when the raw key is invalid.
   /// </summary>
   [Fact]
   public void Constructor_GivenInvalidRawKey_ShouldThrowException()
@@ -55,6 +55,31 @@ public class ConstructorTests
 
     // Assert
     _ = Assert.Throws<ValidationException>(act);
+  }
+
+  /// <summary>
+  /// Tests that an exception is thrown when the raw key is not three lines.
+  /// </summary>
+  [Fact]
+  public void Constructor_GivenRawKeyWithInvalidLineCount_ShouldThrowException()
+  {
+    // Arrange
+    var createdAt = DateTime.SpecifyKind(DateTime.UnixEpoch.AddDays(18400), DateTimeKind.Utc);
+    string publicKey = "age1wrczv4ll5att0mm8tmp4052z4fadw5zefxvefuqxu8rqtpe47chskk9dgn";
+    string privateKey = "AGE-SECRET-KEY-1PW4MMMJ9KMZ94C2N2FM3UPLPQPEF8G9QHXP8VX6V6GW3EN9QMSVQX0ATHQ";
+    string rawKey = $"""
+      # created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}
+      # public key: {publicKey}
+      {privateKey}
+      whoops this key has an extra line
+      """;
+
+    // Act
+    void act() => _ = new AgeKey(rawKey);
+
+    // Assert
+    _ = Assert.Throws<ArgumentException>(act);
+
   }
 
   /// <summary>

--- a/Devantler.Keys.Age.Tests/AgeKeyTests/ConstructorTests.cs
+++ b/Devantler.Keys.Age.Tests/AgeKeyTests/ConstructorTests.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Devantler.Keys.Age.Utils;
 
 namespace Devantler.Keys.Age.Tests.AgeKeyTests;
 
@@ -7,6 +8,55 @@ namespace Devantler.Keys.Age.Tests.AgeKeyTests;
 /// </summary>
 public class ConstructorTests
 {
+  /// <summary>
+  /// Tests that an age key is created with valid data.
+  /// </summary>
+  [Fact]
+  public void Constructor_GivenValidRawKey_ShouldCreateAgeKey()
+  {
+    // Arrange
+    var createdAt = DateTime.SpecifyKind(DateTime.UnixEpoch.AddDays(18400), DateTimeKind.Utc);
+    string publicKey = "age1wrczv4ll5att0mm8tmp4052z4fadw5zefxvefuqxu8rqtpe47chskk9dgn";
+    string privateKey = "AGE-SECRET-KEY-1PW4MMMJ9KMZ94C2N2FM3UPLPQPEF8G9QHXP8VX6V6GW3EN9QMSVQX0ATHQ";
+    string rawKey = $"""
+      # created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}
+      # public key: {publicKey}
+      {privateKey}
+      """;
+
+    // Act
+    var ageKey = new AgeKey(rawKey);
+
+    // Assert
+    Assert.Equal(createdAt, ageKey.CreatedAt);
+    Assert.Equal(publicKey, ageKey.PublicKey);
+    Assert.Equal(privateKey, ageKey.PrivateKey);
+    Assert.Equal(rawKey, ageKey.ToString());
+  }
+
+  /// <summary>
+  /// Tests that an age key is created with valid data.
+  /// </summary>
+  [Fact]
+  public void Constructor_GivenInvalidRawKey_ShouldThrowException()
+  {
+    // Arrange
+    var createdAt = DateTime.SpecifyKind(DateTime.UnixEpoch.AddDays(18400), DateTimeKind.Utc);
+    string publicKey = "age1wrczv4ll5att0mm8tmp4052dont-expect-this-to-workfxvefuqxu8rqtpe47chskk9dgn";
+    string privateKey = "AGE-SECRET-KEY-1PW4MMMJ9KMZ94C2PEFdont-expect-this-to-work8G9QHXP8VX6V6GW3EN9QMSVQX0ATHQ";
+    string rawKey = $"""
+      # created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}
+      # public key: {publicKey}
+      {privateKey}
+      """;
+
+    // Act
+    void act() => _ = new AgeKey(rawKey);
+
+    // Assert
+    _ = Assert.Throws<ValidationException>(act);
+  }
+
   /// <summary>
   /// Tests that an age key is created with valid data.
   /// </summary>

--- a/Devantler.Keys.Age.Tests/AgeKeyTests/ConstructorTests.cs
+++ b/Devantler.Keys.Age.Tests/AgeKeyTests/ConstructorTests.cs
@@ -18,11 +18,7 @@ public class ConstructorTests
     var createdAt = DateTime.SpecifyKind(DateTime.UnixEpoch.AddDays(18400), DateTimeKind.Utc);
     string publicKey = "age1wrczv4ll5att0mm8tmp4052z4fadw5zefxvefuqxu8rqtpe47chskk9dgn";
     string privateKey = "AGE-SECRET-KEY-1PW4MMMJ9KMZ94C2N2FM3UPLPQPEF8G9QHXP8VX6V6GW3EN9QMSVQX0ATHQ";
-    string rawKey = $"""
-      # created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}
-      # public key: {publicKey}
-      {privateKey}
-      """;
+    string rawKey = $"# created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}\n# public key: {publicKey}\n{privateKey}";
 
     // Act
     var ageKey = new AgeKey(rawKey);
@@ -44,11 +40,7 @@ public class ConstructorTests
     var createdAt = DateTime.SpecifyKind(DateTime.UnixEpoch.AddDays(18400), DateTimeKind.Utc);
     string publicKey = "age1wrczv4ll5att0mm8tmp4052dont-expect-this-to-workfxvefuqxu8rqtpe47chskk9dgn";
     string privateKey = "AGE-SECRET-KEY-1PW4MMMJ9KMZ94C2PEFdont-expect-this-to-work8G9QHXP8VX6V6GW3EN9QMSVQX0ATHQ";
-    string rawKey = $"""
-      # created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}
-      # public key: {publicKey}
-      {privateKey}
-      """;
+    string rawKey = $"# created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}\n# public key: {publicKey}\n{privateKey}";
 
     // Act
     void act() => _ = new AgeKey(rawKey);
@@ -67,12 +59,7 @@ public class ConstructorTests
     var createdAt = DateTime.SpecifyKind(DateTime.UnixEpoch.AddDays(18400), DateTimeKind.Utc);
     string publicKey = "age1wrczv4ll5att0mm8tmp4052z4fadw5zefxvefuqxu8rqtpe47chskk9dgn";
     string privateKey = "AGE-SECRET-KEY-1PW4MMMJ9KMZ94C2N2FM3UPLPQPEF8G9QHXP8VX6V6GW3EN9QMSVQX0ATHQ";
-    string rawKey = $"""
-      # created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}
-      # public key: {publicKey}
-      {privateKey}
-      whoops this key has an extra line
-      """;
+    string rawKey = $"# created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}\n# public key: {publicKey}\n{privateKey}\nwhoops this is an extra line";
 
     // Act
     void act() => _ = new AgeKey(rawKey);

--- a/Devantler.Keys.Age.Tests/AgeKeyTests/ConstructorTests.cs
+++ b/Devantler.Keys.Age.Tests/AgeKeyTests/ConstructorTests.cs
@@ -66,7 +66,6 @@ public class ConstructorTests
 
     // Assert
     _ = Assert.Throws<ArgumentException>(act);
-
   }
 
   /// <summary>

--- a/Devantler.Keys.Age.Tests/AgeKeyTests/ConstructorTests.cs
+++ b/Devantler.Keys.Age.Tests/AgeKeyTests/ConstructorTests.cs
@@ -18,7 +18,7 @@ public class ConstructorTests
     var createdAt = DateTime.SpecifyKind(DateTime.UnixEpoch.AddDays(18400), DateTimeKind.Utc);
     string publicKey = "age1wrczv4ll5att0mm8tmp4052z4fadw5zefxvefuqxu8rqtpe47chskk9dgn";
     string privateKey = "AGE-SECRET-KEY-1PW4MMMJ9KMZ94C2N2FM3UPLPQPEF8G9QHXP8VX6V6GW3EN9QMSVQX0ATHQ";
-    string rawKey = $"# created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}\n# public key: {publicKey}\n{privateKey}";
+    string rawKey = $"# created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}{Environment.NewLine}# public key: {publicKey}{Environment.NewLine}{privateKey}";
 
     // Act
     var ageKey = new AgeKey(rawKey);
@@ -40,7 +40,7 @@ public class ConstructorTests
     var createdAt = DateTime.SpecifyKind(DateTime.UnixEpoch.AddDays(18400), DateTimeKind.Utc);
     string publicKey = "age1wrczv4ll5att0mm8tmp4052dont-expect-this-to-workfxvefuqxu8rqtpe47chskk9dgn";
     string privateKey = "AGE-SECRET-KEY-1PW4MMMJ9KMZ94C2PEFdont-expect-this-to-work8G9QHXP8VX6V6GW3EN9QMSVQX0ATHQ";
-    string rawKey = $"# created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}\n# public key: {publicKey}\n{privateKey}";
+    string rawKey = $"# created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}{Environment.NewLine}# public key: {publicKey}{Environment.NewLine}{privateKey}";
 
     // Act
     void act() => _ = new AgeKey(rawKey);
@@ -59,7 +59,7 @@ public class ConstructorTests
     var createdAt = DateTime.SpecifyKind(DateTime.UnixEpoch.AddDays(18400), DateTimeKind.Utc);
     string publicKey = "age1wrczv4ll5att0mm8tmp4052z4fadw5zefxvefuqxu8rqtpe47chskk9dgn";
     string privateKey = "AGE-SECRET-KEY-1PW4MMMJ9KMZ94C2N2FM3UPLPQPEF8G9QHXP8VX6V6GW3EN9QMSVQX0ATHQ";
-    string rawKey = $"# created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}\n# public key: {publicKey}\n{privateKey}\nwhoops this is an extra line";
+    string rawKey = $"# created: {DateTimeFormatter.FormatDateTimeWithCustomOffset(createdAt)}{Environment.NewLine}# public key: {publicKey}{Environment.NewLine}{privateKey}{Environment.NewLine}whoops this is an extra line";
 
     // Act
     void act() => _ = new AgeKey(rawKey);

--- a/Devantler.Keys.Age.Tests/Utils/DateTimeFormatterTests/FormatDateTimeWithCustomOffsetTests.cs
+++ b/Devantler.Keys.Age.Tests/Utils/DateTimeFormatterTests/FormatDateTimeWithCustomOffsetTests.cs
@@ -1,4 +1,6 @@
-namespace Devantler.Keys.Age.Utils.Tests;
+using Devantler.Keys.Age.Utils;
+
+namespace Devantler.Keys.Age.Tests.Utils.DateTimeFormatterTests;
 
 /// <summary>
 /// Tests for the <see cref="DateTimeFormatter.FormatDateTimeWithCustomOffset"/> method.

--- a/Devantler.Keys.Age/AgeKey.cs
+++ b/Devantler.Keys.Age/AgeKey.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 using Devantler.Keys.Core;
 using Devantler.Keys.Age.Utils;
+using System.Globalization;
 
 namespace Devantler.Keys.Age;
 
@@ -10,6 +11,24 @@ namespace Devantler.Keys.Age;
 /// </summary>
 public class AgeKey : IKey
 {
+  /// <summary>
+  /// Creates a new instance of the <see cref="AgeKey"/> class from a raw key.
+  /// </summary>
+  /// <param name="rawKey"></param>
+  [SetsRequiredMembers]
+  public AgeKey(string rawKey)
+  {
+    ArgumentNullException.ThrowIfNull(rawKey);
+
+    string[] lines = rawKey.Split("\n");
+    if (lines.Length != 3)
+      throw new ArgumentException("The key is not in the correct format.");
+    CreatedAt = DateTime.Parse(lines[0].Replace("# created: ", "", StringComparison.InvariantCulture), CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
+    PublicKey = lines[1].Replace("# public key: ", "", StringComparison.InvariantCulture);
+    PrivateKey = lines[2];
+    Validator.ValidateObject(this, new ValidationContext(this), validateAllProperties: true);
+  }
+
   /// <summary>
   /// Creates a new instance of the <see cref="AgeKey"/> class.
   /// </summary>

--- a/Devantler.Keys.Age/AgeKey.cs
+++ b/Devantler.Keys.Age/AgeKey.cs
@@ -22,7 +22,7 @@ public class AgeKey : IKey
 
     string[] lines = rawKey.Split("\n");
     if (lines.Length != 3)
-      throw new ArgumentException("The key is not in the correct format.");
+      throw new ArgumentException("The raw key must have exactly 3 lines.", nameof(rawKey));
     CreatedAt = DateTime.Parse(lines[0].Replace("# created: ", "", StringComparison.InvariantCulture), CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);
     PublicKey = lines[1].Replace("# public key: ", "", StringComparison.InvariantCulture);
     PrivateKey = lines[2];

--- a/Devantler.Keys.Age/AgeKey.cs
+++ b/Devantler.Keys.Age/AgeKey.cs
@@ -20,7 +20,7 @@ public class AgeKey : IKey
   {
     ArgumentNullException.ThrowIfNull(rawKey);
 
-    string[] lines = rawKey.Split("\n");
+    string[] lines = rawKey.Split(Environment.NewLine);
     if (lines.Length != 3)
       throw new ArgumentException("The raw key must have exactly 3 lines.", nameof(rawKey));
     CreatedAt = DateTime.Parse(lines[0].Replace("# created: ", "", StringComparison.InvariantCulture), CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal);


### PR DESCRIPTION
This pull request updates the AgeKey constructor to support creating a key from a raw key. It adds a new constructor that takes a raw key as a parameter and parses it to extract the created date, public key, and private key. It also includes tests to ensure that the constructor works correctly with valid and invalid raw keys.