### PR TITLE
Enable treating warnings as errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,6 +46,9 @@ dotnet_naming_rule.constants_should_be_pascal_case.style = constant_style
 # Apply our rule to constants.
 dotnet_naming_style.constant_style.capitalization = pascal_case
 
+# Disable CA1014
+dotnet_diagnostic.CA1014.severity = none
+
 [*.{received,verified}.*]
 generated_code = true
 

--- a/Devantler.Keys.Age.Tests/Devantler.Keys.Age.Tests.csproj
+++ b/Devantler.Keys.Age.Tests/Devantler.Keys.Age.Tests.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/Devantler.Keys.Age/Devantler.Keys.Age.csproj
+++ b/Devantler.Keys.Age/Devantler.Keys.Age.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>

--- a/Devantler.Keys.Core/Devantler.Keys.Core.csproj
+++ b/Devantler.Keys.Core/Devantler.Keys.Core.csproj
@@ -6,6 +6,7 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>preview-all</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
This pull request includes changes to enable treating warnings as errors in the code. The `.editorconfig` file has been updated to set `TreatWarningsAsErrors` to `true`. Additionally, the `dotnet_diagnostic.CA1014` rule has been disabled. These changes ensure that warnings are treated as errors during the build process.